### PR TITLE
Fix bug when callc hashtable functionTable

### DIFF
--- a/lib/FunctionCaller.c
+++ b/lib/FunctionCaller.c
@@ -69,7 +69,7 @@ int SilikoFunctionCallerInstall(const char *name, SilikoFunctionPointer function
 
 int SilikoFunctionCallerSetUp()
 {
-	if (!(functionTable = calloc(256, sizeof(SilikoFunctionChain))))
+	if (!(functionTable = calloc(256, sizeof(SilikoFunctionChain*))))
 		goto memerr;
 
 	SilikoFunctionCallerInstall("add", SilikoFunction_add);


### PR DESCRIPTION
sizeof(SilikoFunctionChain*) is 8 while sizeof(SilikoFunctionChain) is 24. you just made a typo?